### PR TITLE
New BIO methods

### DIFF
--- a/bio/bio.swig
+++ b/bio/bio.swig
@@ -106,13 +106,23 @@ typedef struct bio_method_st BIO_METHOD;
 
 /* Functions and macros */
 
+BIO_METHOD *   BIO_s_mem(void);
+BIO_METHOD *   BIO_s_file(void);
+
 extern int BIO_free(BIO *a);
-// extern BIO *BIO_new(BIO_METHOD *method);
+extern BIO *BIO_new(BIO_METHOD *method);
 // extern int BIO_make_bio_pair(BIO *bp1, BIO *bp2);
 
 /* File */
 extern BIO *BIO_new_file(const char *filename, const char *mode);
 extern int BIO_puts(BIO *bp, const char *buf);
+
+int BIO_read_filename(BIO *b, char *name);
+int BIO_write_filename(BIO *b, char *name);
+int BIO_append_filename(BIO *b, char *name);
+int BIO_rw_filename(BIO *b, char *name);
+
+int BIO_printf(BIO *bio, const char *format, ...);
 
 %typemap(gotype) char *outbuf %{[]byte%}
 %typemap(in) char *outbuf {

--- a/bio/bio.swig
+++ b/bio/bio.swig
@@ -126,7 +126,7 @@ int BIO_printf(BIO *bio, const char *format, ...);
 
 %typemap(gotype) char *outbuf %{[]byte%}
 %typemap(in) char *outbuf {
-	char tbuf[sizeof($input)];
+	char tbuf[sizeof($input.array)*sizeof(char*)];
 	$1 = (char *)&tbuf;
 }
 
@@ -141,7 +141,7 @@ extern long BIO_flush(BIO *bp);
 
 %typemap(gotype) void *buf %{[]byte%}
 %typemap(in) void *buf {
-    char tbuf[sizeof($input)];
+    char tbuf[sizeof($input.array)*sizeof(char*)];
     $1 = (void*)&tbuf;
 }
 %typemap(argout) void *buf {

--- a/bio/bio.swig
+++ b/bio/bio.swig
@@ -139,6 +139,18 @@ extern int BIO_gets(BIO *bp, char *outbuf, int size);
 extern long BIO_seek(BIO *bp, int ofs);
 extern long BIO_flush(BIO *bp);
 
+%typemap(gotype) void *buf %{[]byte%}
+%typemap(in) void *buf {
+    char tbuf[sizeof($input)];
+    $1 = (void*)&tbuf;
+}
+%typemap(argout) void *buf {
+    memcpy($input.array, $1, $input.cap);
+    $input.len = strlen($1);
+}
+
+int BIO_read(BIO *b, void *buf, int len);
+
 /* Connect */
 // BIO_METHOD *BIO_s_connect(void);
 extern BIO *BIO_new_connect(char *name);

--- a/bio/bio.swig
+++ b/bio/bio.swig
@@ -151,6 +151,19 @@ extern long BIO_flush(BIO *bp);
 
 int BIO_read(BIO *b, void *buf, int len);
 
+%typemap(gotype) const void *buf %{string%}
+%typemap(in) const void *buf {
+    char tbuf[sizeof($input.p)*sizeof(char*)];
+    $1 = (const void*)&tbuf;
+    memcpy($1, $input.p, $input.n);
+}
+%typemap(argout) const void *buf {
+    $input.p = $1;
+    $input.n = strlen($1);
+}
+
+int BIO_write(BIO *b, const void *buf, int len);
+
 /* Connect */
 // BIO_METHOD *BIO_s_connect(void);
 extern BIO *BIO_new_connect(char *name);

--- a/bio/bio_test.go
+++ b/bio/bio_test.go
@@ -60,7 +60,6 @@ var _ = Describe("Bio", func() {
 				b = BIO_new(BIO_s_file())
 				Expect(BIO_write_filename(b, "biotest.out")).To(Equal(1))
 				Expect(BIO_seek(b, 0)).To(BeEquivalentTo(0))
-				// Expect(BIO_printf(b, text)).To(Equal(len(text)))
 				Expect(BIO_write(b, text, len(text))).To(Equal(len(text)))
 				Expect(BIO_free(b)).To(Equal(1))
 			})

--- a/bio/bio_test.go
+++ b/bio/bio_test.go
@@ -10,6 +10,63 @@ import (
 
 var _ = Describe("Bio", func() {
 	Describe("Basic I/O", func() {
+		var (
+			b    BIO
+			text = "Some test data"
+		)
+
+		Context("Using a memory store", func() {
+			It("Should create a new bio using memory store", func() {
+				b = BIO_new(BIO_s_mem())
+				Expect(b).NotTo(BeNil())
+			})
+
+			It("Should be writable", func() {
+				r := BIO_puts(b, text)
+				Expect(r).NotTo(Equal(-2))
+			})
+
+			It("Should be readable", func() {
+				buf := make([]byte, len(text))
+				r := BIO_gets(b, buf, len(text)+1)
+				Expect(r).To(Equal(len(text)))
+				Expect(string(buf)).To(Equal(text))
+			})
+
+			It("Should free the memory store bio", func() {
+				Expect(BIO_free(b)).To(Equal(1))
+			})
+		})
+
+		Context("Using file storage", func() {
+			It("Should create a new bio using file storage", func() {
+				b = BIO_new(BIO_s_file())
+				Expect(b).NotTo(BeNil())
+			})
+
+			It("Should free the file storage bio", func() {
+				Expect(BIO_free(b)).To(Equal(1))
+			})
+
+			It("Should be writable with BIO_printf", func() {
+				b = BIO_new(BIO_s_file())
+				Expect(BIO_write_filename(b, "biotest.out")).To(Equal(1))
+				Expect(BIO_seek(b, 0)).To(BeEquivalentTo(0))
+				Expect(BIO_printf(b, text)).To(Equal(len(text)))
+				Expect(BIO_free(b)).To(Equal(1))
+			})
+
+			It("Should be readable", func() {
+				buf := make([]byte, len(text))
+				b = BIO_new(BIO_s_file())
+				Expect(BIO_read_filename(b, "biotest.out")).To(Equal(1))
+				Expect(BIO_seek(b, 0)).To(BeEquivalentTo(0))
+				Expect(BIO_gets(b, buf, len(text)+1)).To(Equal(len(text)))
+				Expect(string(buf)).To(Equal(text))
+				Expect(BIO_free(b)).To(Equal(1))
+			})
+		})
+
 		Context("Making a connection", func() {
 			It("Connects successfully", func() {
 				dest := "www.google.com:http"
@@ -35,7 +92,7 @@ var _ = Describe("Bio", func() {
 				/* Assumes only a single BIO in the chain... */
 				Expect(BIO_free(fbio)).To(Equal(1))
 			})
-	
+
 			It("Writes to the file, reads using native Go I/O", func() {
 				Expect(BIO_puts(fbio, text)).To(BeNumerically(">=", 1))
 				Expect(BIO_flush(fbio)).To(BeEquivalentTo(1))
@@ -54,7 +111,7 @@ var _ = Describe("Bio", func() {
 				Expect(BIO_seek(fbio, 0)).To(BeEquivalentTo(0))
 
 				rbuf := make([]byte, len(text))
-				l := BIO_gets(fbio, rbuf, len(text) +1)
+				l := BIO_gets(fbio, rbuf, len(text)+1)
 				/* Check that we've read enough bytes */
 				Expect(l).To(BeNumerically(">=", len(text)))
 

--- a/bio/bio_test.go
+++ b/bio/bio_test.go
@@ -56,12 +56,22 @@ var _ = Describe("Bio", func() {
 				Expect(BIO_free(b)).To(Equal(1))
 			})
 
-			It("Should be readable", func() {
+			It("Should be readable with BIO_gets", func() {
 				buf := make([]byte, len(text))
 				b = BIO_new(BIO_s_file())
 				Expect(BIO_read_filename(b, "biotest.out")).To(Equal(1))
 				Expect(BIO_seek(b, 0)).To(BeEquivalentTo(0))
 				Expect(BIO_gets(b, buf, len(text)+1)).To(Equal(len(text)))
+				Expect(string(buf)).To(Equal(text))
+				Expect(BIO_free(b)).To(Equal(1))
+			})
+
+			It("Should be readable with BIO_read", func() {
+				buf := make([]byte, len(text))
+				b = BIO_new(BIO_s_file())
+				Expect(BIO_read_filename(b, "biotest.out")).To(Equal(1))
+				Expect(BIO_seek(b, 0)).To(BeEquivalentTo(0))
+				Expect(BIO_read(b, buf, len(text)+1)).To(Equal(len(text)))
 				Expect(string(buf)).To(Equal(text))
 				Expect(BIO_free(b)).To(Equal(1))
 			})

--- a/bio/bio_test.go
+++ b/bio/bio_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Bio", func() {
 	Describe("Basic I/O", func() {
 		var (
 			b    BIO
-			text = "Some test data"
+			text = "Some really really really really really really long test data"
 		)
 
 		Context("Using a memory store", func() {

--- a/bio/bio_test.go
+++ b/bio/bio_test.go
@@ -56,6 +56,15 @@ var _ = Describe("Bio", func() {
 				Expect(BIO_free(b)).To(Equal(1))
 			})
 
+			It("Should be writable with BIO_write", func() {
+				b = BIO_new(BIO_s_file())
+				Expect(BIO_write_filename(b, "biotest.out")).To(Equal(1))
+				Expect(BIO_seek(b, 0)).To(BeEquivalentTo(0))
+				// Expect(BIO_printf(b, text)).To(Equal(len(text)))
+				Expect(BIO_write(b, text, len(text))).To(Equal(len(text)))
+				Expect(BIO_free(b)).To(Equal(1))
+			})
+
 			It("Should be readable with BIO_gets", func() {
 				buf := make([]byte, len(text))
 				b = BIO_new(BIO_s_file())


### PR DESCRIPTION
Adds `BIO_new`, `BIO_s_mem`, `BIO_s_file`, `BIO_read_filename`, `BIO_write_filename`, `BIO_append_filename`, `BIO_rw_filename`, `BIO_printf`, `BIO_read`, and `BIO_write` methods with their appropriate tests.

Also fixes existing stack smashing issue with `BIO_gets`.